### PR TITLE
Code Cleanup

### DIFF
--- a/AndroidTool/Apk.swift
+++ b/AndroidTool/Apk.swift
@@ -26,26 +26,25 @@ class Apk: NSObject {
     
      func parseRawInfo(_ rawdata:String) {
             print(">>apkparskeapkinfo")
-            let u = Util()
             let apk = self
             
-            if let l = u.findMatchesInString(rawdata, regex: "launchable-activity: name='(.*?)'") {
+            if let l = rawdata.matches("launchable-activity: name='(.*?)'") {
                 apk.launcherActivity = l[0]
             }
             
-            if let n = u.findMatchesInString(rawdata, regex: "application-label:'(.*?)'") {
+            if let n = rawdata.matches("application-label:'(.*?)'") {
                 apk.appName = n[0]
             }
             
-            if let p = u.findMatchesInString(rawdata, regex: "package: name='(.*?)'") {
+            if let p = rawdata.matches("package: name='(.*?)'") {
                 apk.packageName = p[0]
             }
             
-            if let versionCode = u.findMatchesInString(rawdata, regex: "versionCode='(.*?)'") {
+            if let versionCode = rawdata.matches("versionCode='(.*?)'") {
                 apk.versionCode = versionCode[0]
             }
 
-            if let versionName = u.findMatchesInString(rawdata, regex: "versionName='(.*?)'") {
+            if let versionName = rawdata.matches("versionName='(.*?)'") {
                 apk.versionName = versionName[0]
             }
         }

--- a/AndroidTool/AppDelegate.swift
+++ b/AndroidTool/AppDelegate.swift
@@ -71,7 +71,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     @IBAction func revealFolderClicked(_ sender: NSMenuItem) {
-        Util().revealScriptsFolder()
+        filesystem.revealScriptsFolder()
     }
     
     func checkForPreferences(){
@@ -128,24 +128,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         scriptsMenu.addItem(screenshotItem)
         scriptsMenu.addItem(sepItem)
         
-        Util().setUpSupportFolderScriptPath()
-        let supportDir = Util().getSupportFolderScriptPath()
-        let scriptFiles = Util().getScriptsInScriptFolder(supportDir)!
+        try? filesystem.setUpSupportFolderScriptPath()
+        let supportDir = filesystem.supportFolderScriptPath()
+        let scriptFiles = filesystem.scriptsInScriptFolder(supportDir)
 
-        var i = 0
-        for scriptFile in scriptFiles {
-
+        for (i, scriptFile) in scriptFiles.enumerated() {
             // for scripts 0..9, add a keyboard shortcut
             var keyEq = ""
             if i<10 {
                 keyEq = "\(i)"
-                }
+            }
             let scriptItem = NSMenuItem(
                 title: scriptFile.replacingOccurrences(of: ".sh", with: ""),
                 action: #selector(runScript),
                 keyEquivalent: keyEq)
             scriptsMenu.addItem(scriptItem)
-            i += 1
         }
         
         scriptsMenu.addItem(sepItem2)
@@ -153,8 +150,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     @objc func runScript(_ sender:NSMenuItem){
-        Util().stopRefreshingDeviceList()
-        let scriptPath = "\(Util().getSupportFolderScriptPath())/\(sender.title).sh"
+        DeviceList.stopRefreshing()
+        let scriptPath = "\(filesystem.supportFolderScriptPath())/\(sender.title).sh"
         print("ready to run \(scriptPath) on all Android devices")
         
         let deviceVCs = masterViewController.deviceVCs
@@ -167,17 +164,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         }
-        
-        Util().restartRefreshingDeviceList()
+        DeviceList.restartRefreshing()
     }
     
     @IBAction func screenshotsOfAllTapped(_ sender: NSMenuItem) { // TODO:clicked, not tapped
-        Util().stopRefreshingDeviceList()
+        DeviceList.stopRefreshing()
         let deviceVCs = masterViewController.deviceVCs
         for deviceVC in deviceVCs {
             deviceVC.takeScreenshot()
         }
-        Util().restartRefreshingDeviceList()
+        DeviceList.restartRefreshing()
     }
     
     func applicationWillResignActive(_ notification: Notification) {

--- a/AndroidTool/Device.swift
+++ b/AndroidTool/Device.swift
@@ -9,10 +9,6 @@
 import Cocoa
 import AVFoundation
 
-protocol DeviceDelegate{
-    //
-}
-
 enum DeviceType:String {
     case Phone="Phone", Watch="Watch", Tv="Tv", Auto="Auto"
 }
@@ -42,8 +38,7 @@ class Device: NSObject {
     var currentActivity : String = ""
     
     convenience init(avDevice:AVCaptureDevice) {
-        self.init()
-        deviceOS = DeviceOS.ios
+        self.init(deviceOS: .ios)
         firstBoot = hashFromString(avDevice.uniqueID)
         brand = "Apple"
         name = avDevice.localizedName
@@ -53,10 +48,9 @@ class Device: NSObject {
     }
     
     convenience init(properties:[String:String], adbIdentifier:String) {
-        self.init()
+        self.init(deviceOS: .android)
         
-        deviceOS = .android
-        self.adbIdentifier = adbIdentifier.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        self.adbIdentifier = adbIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
         
         model = properties["ro.product.model"]
         name = properties["ro.product.name"]
@@ -91,6 +85,10 @@ class Device: NSObject {
                 print("Awkward. No size found. What I did find was \(res)")
             }
         }
+    }
+    
+    init(deviceOS: DeviceOS) {
+        self.deviceOS = deviceOS
     }
     
     

--- a/AndroidTool/DeviceDiscoverer.swift
+++ b/AndroidTool/DeviceDiscoverer.swift
@@ -23,7 +23,7 @@ class DeviceDiscoverer:NSObject, IOSDeviceDelegate {
     var iosDeviceHelper: IOSDeviceHelper?
     var iosDevices = [Device]()
     var androidDevices = [Device]()
-    let pollLock = ""
+    let pollLock = Lock()
     
     func start(){
         let checkTask = ShellTasker(scriptFile: "checkEnvironment")
@@ -103,7 +103,7 @@ class DeviceDiscoverer:NSObject, IOSDeviceDelegate {
     }
     
     @objc func pollDevices(){
-        Util.synced(pollLock) {
+        pollLock.synced {
             var newDevices = [Device]()
             print("+", terminator: "")
             
@@ -129,7 +129,7 @@ class DeviceDiscoverer:NSObject, IOSDeviceDelegate {
     }
     
     @objc func startPollingDevices() {
-        Util.synced(pollLock) {
+        pollLock.synced {
             stopPollingDevices()
             mainTimer = Timer.scheduledTimer(
                 timeInterval: updateInterval,
@@ -141,7 +141,7 @@ class DeviceDiscoverer:NSObject, IOSDeviceDelegate {
     }
     
     @objc func stopPollingDevices() {
-        Util.synced(pollLock) {
+        pollLock.synced {
             if let timer = mainTimer {
                 timer.invalidate()
                 mainTimer = nil

--- a/AndroidTool/DevicePickerViewController.swift
+++ b/AndroidTool/DevicePickerViewController.swift
@@ -42,9 +42,9 @@ class DevicePickerViewController: NSViewController, NSTableViewDelegate, NSTable
         spinner.startAnimation(nil)
         
         guard let apkPath = apkPath else {
-            Util
-                .showNotification("APK Path wasn't set yet.",
-                                    moreInfo: "")
+            NSUserNotification
+                .deliver("APK Path wasn't set yet.",
+                         moreInfo: "")
             return
         }
         let args = ["\(adbIdentifier)",
@@ -52,7 +52,7 @@ class DevicePickerViewController: NSViewController, NSTableViewDelegate, NSTable
         
         ShellTasker(scriptFile: "installApkOnDevice").run(arguments: args) { (output) -> Void in
 
-            Util.showNotification("App installed on \(device.readableIdentifier())", moreInfo: "\(output)", sound: true)
+            NSUserNotification.deliver("App installed on \(device.readableIdentifier())", moreInfo: "\(output)", sound: true)
             if #available(OSX 10.10, *) {
                 self.dismiss(nil)
             } else {

--- a/AndroidTool/DeviceViewController.swift
+++ b/AndroidTool/DeviceViewController.swift
@@ -99,7 +99,7 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
             ShellTasker(scriptFile: "takeScreenshotOfDeviceWithUUID").run(arguments: args, isUserScript: false, isIOS: true, complete: { (output) -> Void in
                 self.setStatus("Screenshot ready")
                 self.stopProgressIndication()
-                Util.showNotification("Screenshot ready", moreInfo: "", sound: true)
+                NSUserNotification.deliver("Screenshot ready", moreInfo: "", sound: true)
                 self.setStatus("Screenshot ready")
             })
             
@@ -148,7 +148,7 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
         ]
         
         ShellTasker(scriptFile: "takeScreenshotOfDeviceWithSerial").run(arguments: args) { (output) -> Void in
-            Util.showNotification("Screenshot ready", moreInfo: "", sound: true)
+            NSUserNotification.deliver("Screenshot ready", moreInfo: "", sound: true)
             self.exitDemoModeIfNeeded()
             self.stopProgressIndication()
             self.setStatus("Screenshot ready")
@@ -172,13 +172,13 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
     func userScriptEnded() {
         setStatus("Script finished")
         stopProgressIndication()
-        Util().restartRefreshingDeviceList()
+        DeviceList.restartRefreshing()
     }
     
     func userScriptStarted() {
         setStatus("Script running")
         startProgressIndication()
-        Util().stopRefreshingDeviceList()
+        DeviceList.stopRefreshing()
     }
     
     func userScriptWantsSerial() -> String {
@@ -186,12 +186,12 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
     }
     
     func popoverDidClose(_ notification: Notification) {
-        Util().restartRefreshingDeviceList()
+        DeviceList.restartRefreshing()
         moreOpen = false
     }
 
     @IBAction func moreClicked(_ sender: NSButton) {
-        Util().stopRefreshingDeviceList()
+        DeviceList.stopRefreshing()
         if !moreOpen{
             moreOpen = true
             scriptsPopover.show(relativeTo: sender.bounds, of: sender, preferredEdge: NSRectEdge(rawValue: 2)!)
@@ -231,7 +231,7 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
     
     func startRecording(){
         setStatus("Starting screen recording")
-        Util().stopRefreshingDeviceList()
+        DeviceList.stopRefreshing()
         isRecording = true
         self.restingButton = self.videoButton.image // restingbutton is "recordButtonWhite"
         videoButton.image = NSImage(named: "stopButton")
@@ -301,7 +301,7 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
             let postProcessTask = ShellTasker(scriptFile: "postProcessMovieForSerial")
 
             postProcessTask.run(arguments: args, complete: { (output) -> Void in
-                Util.showNotification("Your recording is ready", moreInfo: "", sound: true)
+                NSUserNotification.deliver("Your recording is ready", moreInfo: "", sound: true)
                 self.exitDemoModeIfNeeded()
                 self.setStatus("Recording finished")
                 self.stopProgressIndication()
@@ -313,7 +313,7 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
         NSWorkspace.shared.openFile(outputFileURL.path)
         self.videoButton.image = restingButton
         
-        Util.showNotification("Your recording is ready", moreInfo: "", sound: true)
+        NSUserNotification.deliver("Your recording is ready", moreInfo: "", sound: true)
         cameraButton.isEnabled = true
         
         let movPath = outputFileURL.path
@@ -335,7 +335,7 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
     }
     
     func stopRecording(){
-        Util().restartRefreshingDeviceList()
+        DeviceList.restartRefreshing()
         isRecording = false
         videoButton.alphaValue = 1
 
@@ -355,8 +355,8 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
         }
     }
     
-    init?(device _device:Device){
-        device = _device
+    init?(device:Device){
+        self.device = device
         super.init(nibName: "DeviceViewController", bundle: nil)
         setup()
     }
@@ -380,14 +380,14 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
     }
     
     func startProgressIndication(){
-        Util().stopRefreshingDeviceList()
+        DeviceList.stopRefreshing()
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + DispatchTimeInterval.seconds(1)) { () -> Void in
                 self.loaderButton.startRotating()
             }
     }
     
     func stopProgressIndication(){
-        Util().restartRefreshingDeviceList()
+        DeviceList.restartRefreshing()
 //        progressBar.stopAnimation(nil)
         loaderButton.stopRotatingAndReset()
     }
@@ -465,13 +465,13 @@ class DeviceViewController: NSViewController, NSPopoverDelegate, UserScriptDeleg
     
     
     func hideButtons(){
-        Util().fadeViewsOutStaggered([moreButton, cameraButton, videoButton])
+        fadeViewsOutStaggered([moreButton, cameraButton, videoButton])
         uninstallButton.alphaValue = 0
     }
     
     
     func showButtons(){
-        Util().fadeViewsInStaggered([moreButton, cameraButton, videoButton])
+        fadeViewsInStaggered([moreButton, cameraButton, videoButton])
         uninstallButton.alphaValue = 1
     }
     

--- a/AndroidTool/MasterViewController.swift
+++ b/AndroidTool/MasterViewController.swift
@@ -117,13 +117,14 @@ class MasterViewController:
         if newSig != previousSig  {
             
             // adjust window height accordingly
-            var newHeight = Util().deviceHeight
+            let deviceHeight:CGFloat = 127
+            var newHeight = deviceHeight
             if devices.count != 0 {
                 newHeight = CGFloat(devices.count) * newHeight + 20
             } else {
                 newHeight = 171 // emptystate height
             }
-            Util().changeWindowHeight(window, view: self.view, newHeight: newHeight)
+            changeWindowHeight(window, view: view, newHeight: newHeight)
             
             previousSig = newSig
             devicesTable.reloadData()

--- a/AndroidTool/ObbHandler.swift
+++ b/AndroidTool/ObbHandler.swift
@@ -8,35 +8,35 @@
 
 import Cocoa
 
-protocol ObbHandlerDelegate {
-    func obbHandlerDidStart(_ bytes:String)
+protocol ObbHandlerDelegate: AnyObject {
+    func obbHandlerDidStart(_ bytes: String)
     func obbHandlerDidFinish()
 }
 
-class ObbHandler: NSObject {
-    var filePath:String!
-    var delegate:ObbHandlerDelegate?
-    var device:Device!
-    var fileSize:UInt64?
+class ObbHandler {
+    var filePath: String
+    var delegate: ObbHandlerDelegate?
+    var device: Device
+    var fileSize: UInt64
     
-    init(filePath:String, device:Device){
+    init(filePath: String,
+         device:Device){
         print(">>obb init obbhandler")
-        super.init()
+        fileSize = filesystem.sizeOfFileAtPath(filePath)
         self.filePath = filePath
         self.device = device
-        self.fileSize = Util.getFileSizeForFilePath(filePath)
     }
     
     func pushToDevice(){
         print(">>zip flash")
 
         let shell = ShellTasker(scriptFile: "installObbForSerial")
-        let bytes = (fileSize != nil) ? Util.formatBytes(fileSize!) : "? bytes"
+        let bytes = String(byteCount: fileSize)
         
         delegate?.obbHandlerDidStart(bytes)
         
         print("startin obb copying the \(bytes) file")
-        shell.run(arguments: [self.device.adbIdentifier!, self.filePath]) { (output) -> Void in
+        shell.run(arguments: [device.adbIdentifier!, filePath]) { (output) -> Void in
             print("done copying OBB to device")
             self.delegate?.obbHandlerDidFinish()
         }

--- a/AndroidTool/Styles.swift
+++ b/AndroidTool/Styles.swift
@@ -8,20 +8,16 @@
 
 import Cocoa
 
-class Styles: NSObject {
+extension Dictionary where Key == NSAttributedString.Key, Value == Any {
     
-    override init() {
-        super.init()
-    }
-    
-    func terminalAtts() -> [NSAttributedString.Key:Any]{
+    static func terminalAtts() -> [NSAttributedString.Key:Any]{
         var atts = [NSAttributedString.Key:Any]()
         atts[.foregroundColor] = NSColor(red:0.671, green:0.671, blue:0.671, alpha:1)
         atts[.font] = NSFont(name: "Monaco", size: 8.0)
         return atts
     }
     
-    func commandAtts() -> [NSAttributedString.Key:Any]{
+    static func commandAtts() -> [NSAttributedString.Key:Any]{
         var atts = [NSAttributedString.Key:Any]()
         atts[.foregroundColor] = NSColor(red:1, green:1, blue:1, alpha:1)
         atts[.font] = NSFont(name: "Monaco", size: 8.0);

--- a/AndroidTool/TerminalOutputTextView.swift
+++ b/AndroidTool/TerminalOutputTextView.swift
@@ -58,7 +58,7 @@ class TerminalOutputTextView: NSTextView {
             Swift.print("#mj.newData notif")
             DispatchQueue.main.async(execute: { () -> Void in
                 let s = notif.object as! String
-                self.append("\n\n\(s)", atts: Styles().commandAtts())
+                self.append("\n\n\(s)", atts: .commandAtts())
             })
         }
         
@@ -69,7 +69,7 @@ class TerminalOutputTextView: NSTextView {
             if wantsVerbose {
                 DispatchQueue.main.async(execute: { () -> Void in
                     let s = notif.object as! String
-                    self.append("\n\n\(s)", atts: Styles().commandAtts())
+                    self.append("\n\n\(s)", atts: .commandAtts())
                 })
             }
         }
@@ -86,7 +86,7 @@ class TerminalOutputTextView: NSTextView {
         append("\n\n----\n\n")
     }
     
-    func append(_ appended: String, atts:[NSAttributedString.Key:Any] = Styles().terminalAtts()) {
+    func append(_ appended: String, atts:[NSAttributedString.Key:Any] = .terminalAtts()) {
         let s = NSAttributedString(string: "\n"+appended, attributes: atts)
         self.textStorage?.append(s)
         self.scrollToEndOfDocument(nil)

--- a/AndroidTool/UITweaker.swift
+++ b/AndroidTool/UITweaker.swift
@@ -51,14 +51,12 @@ class UITweaker: NSObject {
                     if ud.bool(forKey: prop) { show = "show" }
                     let tweak = Tweak(command: "\(cmd) -e \(prop) \(show)", description: "\(show) \(prop)")
                     tweaks.append(tweak)
-                    break
                 case "location", "alarm", "sync", "tty", "eri", "mute", "speakerphone": // status showhide
                     let cmd = "status"
                     var show = "hide"
                     if ud.bool(forKey: prop) { show = "show" }
                     let tweak = Tweak(command: "\(cmd) -e \(prop) \(show)", description: "\(show) \(prop)")
                     tweaks.append(tweak)
-                    break
                 case "bluetooth":
                     var show = "hide"
                     if ud.bool(forKey: "bluetooth") {
@@ -66,7 +64,6 @@ class UITweaker: NSObject {
                     }
                     let tweak = Tweak(command: "status -e bluetooth \(show)", description: "Tweaking Bluetooth")
                     tweaks.append(tweak)
-                    break
                 case "notifications":
                     var visible = "false"
                     if ud.bool(forKey: prop) {
@@ -74,14 +71,12 @@ class UITweaker: NSObject {
                     }
                     let tweak = Tweak(command: "\(prop) -e visible \(visible)", description: "Tweaking notfications")
                     tweaks.append(tweak)
-                    break
                 case "clock":
                     if ud.bool(forKey: prop) {
                         let hhmm = formatTime(ud.string(forKey: C.PREF_TIME_VALUE)!)
                         let tweak = Tweak(command: "clock -e hhmm \(hhmm)", description: "Setting time to \(ud.string(forKey: C.PREF_TIME_VALUE)!)")
                         tweaks.append(tweak)
                     }
-                    break
                 case "wifi":
                     var show = "hide"
                     var level = ""
@@ -91,7 +86,6 @@ class UITweaker: NSObject {
                     }
                     let tweak = Tweak(command: "network -e \(prop) \(show) \(level)", description: "\(show) \(prop)")
                     tweaks.append(tweak)
-                    break
                 case "mobile":
                     var tweak:Tweak!
                     if ud.bool(forKey: prop){
@@ -102,7 +96,6 @@ class UITweaker: NSObject {
                         tweak = Tweak(command: "network -e mobile hide", description: "Turn cell icon off")
                     }
                     tweaks.append(tweak)
-                    break
                 case "batteryCharging":
                     var showCharging = "false"
                     var description = "Set battery not charging"
@@ -113,7 +106,6 @@ class UITweaker: NSObject {
                     }
                     let tweak = Tweak(command: "battery -e plugged \(showCharging) -e level \(batLevel!)", description: description)
                     tweaks.append(tweak)
-                break
                 default:
                     break
             }

--- a/AndroidTool/Util.swift
+++ b/AndroidTool/Util.swift
@@ -11,165 +11,43 @@ import AppKit
 
 private let deleteToResetName = "delete_to_reset"
 
-class Util {
-    var deviceWidth:CGFloat = 373
-    var deviceHeight:CGFloat = 127
+class DeviceList {
+    
+    static func restartRefreshing(){
+        postNotification(namd: "unSuspendAdb")
+    }
+    
+    static func stopRefreshing(){
+        postNotification(namd: "suspendAdb")
+    }
+    
+    private static func postNotification(namd name: String) {
+        NotificationCenter
+            .default
+            .post(name: Notification.Name(rawValue: name), object: self, userInfo:nil)
+    }
+    
+}
 
-    // view is self.view
-    func changeWindowSize(_ window:NSWindow, view:NSView, addHeight:CGFloat=0, addWidth:CGFloat=0) {
-        var frame = window.frame
-        frame.size = CGSize(width: frame.size.width+addWidth, height: frame.size.height+addHeight)
-        frame.origin.y -= addHeight
-        window.setFrame(frame, display: true, animate: true)
-        view.frame.size.height += addHeight
-        view.frame.origin.y -= addHeight
-    }
+extension NSViewController {
     
-    
-    func changeWindowHeight(_ window:NSWindow, view:NSView, newHeight:CGFloat=0) {
-        var frame = window.frame
-        frame.origin.y += frame.size.height; // origin.y is top Y coordinate now
-        frame.origin.y -= newHeight // new Y coordinate for the origin
-        frame.size.height = newHeight
-        frame.size = CGSize(width: frame.size.width, height: newHeight)
-        window.setFrame(frame, display: true, animate: true)
-    }
-
-    
-    static func showNotification(_ title:String, moreInfo:String, sound:Bool=true) -> Void {
-        let unc = NSUserNotificationCenter.default
-        
-        let notification = NSUserNotification()
-        notification.title = title
-        notification.informativeText = moreInfo
-        if sound == true {
-            notification.soundName = NSUserNotificationDefaultSoundName
-        }
-        unc.deliver(notification)
-    }
-    
-    func getSupportFolderScriptPath() -> String {
-        let supportFolder:String = NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.applicationSupportDirectory, FileManager.SearchPathDomainMask.userDomainMask, true)[0]
-        let folder = "\(supportFolder)/AndroidTool"
-        let scriptFolder = "\(folder)/UserScripts"
-        return scriptFolder
-    }
- 
-    func setUpSupportFolderScriptPath() {
-        let fileM = FileManager.default
-        let scriptFolder = getSupportFolderScriptPath()
-        
-        let scriptUrl = URL.init(fileURLWithPath: scriptFolder)
-        do {
-            try fileM.createDirectory(at: scriptUrl, withIntermediateDirectories: true, attributes: nil)
-            let deleteToReset = scriptUrl.appendingPathComponent(deleteToResetName)
-            if let appVersion = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String {
-                if fileM.fileExists(atPath: deleteToReset.path) {
-                    if (Util.checkVersionMatch(appVersion: appVersion, pathToVersionFile: deleteToReset)) {
-                        // it a match, do nothing
-                        return
-                    } else {
-                        try fileM.removeItem(at: deleteToReset)
-                    }
-                }
-                Util.copyInceptionScripts(userScriptFolder: scriptFolder)
-                try appVersion.write(to: deleteToReset, atomically: false, encoding: .utf8)
-            }
-        } catch _ {}
-    }
-    
-    private static func checkVersionMatch(appVersion: String, pathToVersionFile: URL) -> Bool {
-        do {
-            let savedVersion = try String(contentsOf: pathToVersionFile, encoding: .utf8)
-            return appVersion == savedVersion
-        } catch _ { }
-        return false
-    }
-    
-    private static func copyInceptionScripts(userScriptFolder: String) {
-        let fileM = FileManager.default
-        // copy files from UserScriptsInception to this new folder
-        if let resourceDir = Bundle.main.resourcePath {
-            let inceptionScriptDir = "\(resourceDir)/UserScriptsInception"
-            do {
-                for fileName in try fileM.contentsOfDirectory(atPath: inceptionScriptDir) {
-                    let destFile = "\(userScriptFolder)/\(fileName)"
-                    if fileM.fileExists(atPath: destFile) {
-                        try fileM.removeItem(atPath: destFile)
-                    }
-                    try fileM.copyItem(
-                        atPath: "\(inceptionScriptDir)/\(fileName)",
-                        toPath: destFile)
-                }
-            } catch _ {
-            }
+    func fadeViewsOutStaggered(_ views:[NSView]){
+        var delay:CFTimeInterval = 0
+        for view in views {
+            fadeViewTo(0, view: view, delay: delay)
+            delay += staggerDelay
         }
     }
-    
-    func revealScriptsFolder(){
-        let folder = getSupportFolderScriptPath()
-        NSWorkspace.shared.openFile(folder)
-        }
-    
-    func getScriptsInScriptFolder(_ folder:String) -> [String]? {
-        let fileM = FileManager.default
-        var files = [String]()
-        let someFiles = fileM.enumerator(atPath: folder)
-        while let file = someFiles?.nextObject() as? String  {
-            if file != ".DS_Store" && file != deleteToResetName {
-                files.append(file)
-            }
-        }
-        return files
-    }
-    
-    func restartRefreshingDeviceList(){
-        NotificationCenter.default.post(name: Notification.Name(rawValue: "unSuspendAdb"), object: self, userInfo:nil)
-    }
-    
-    func stopRefreshingDeviceList(){
-        NotificationCenter.default.post(name: Notification.Name(rawValue: "suspendAdb"), object: self, userInfo:nil)
-    }
-    
-    func findMatchesInString(_ rawdata:String, regex:String) -> [String]? {
-        do {
-            let re = try NSRegularExpression(pattern: regex,
-                options: NSRegularExpression.Options.caseInsensitive)
-            
-            let matches = re.matches(in: rawdata,
-                options: NSRegularExpression.MatchingOptions.reportProgress,
-                range:
-                NSRange(location: 0, length: rawdata.utf16.count))
-            
-            if matches.count != 0 {
-                var results = [String]()
-                for match in matches {
-                    let result = (rawdata as NSString).substring(with: match.range(at: 1))
-                    results.append(result)
-                }
-                return results
-            }
-            else {
-                return nil
-            }
-            
-        } catch {
-            print("Problem!")
-            return nil
-        }
-    }
-    
-    
     
     func fadeViewTo(_ alphaValue:Float, view:NSView, delay:CFTimeInterval=0){
         view.wantsLayer = true
-
+        
         let fade = CABasicAnimation(keyPath: "opacity")
         fade.duration = 0.3
         fade.beginTime = CACurrentMediaTime() + delay
         fade.toValue = alphaValue
         fade.timingFunction = CAMediaTimingFunction(name: .easeOut)
-
+        
         
         let move = CABasicAnimation(keyPath: "position.y")
         if alphaValue == 0 {
@@ -189,10 +67,11 @@ class Util {
         
         view.layer?.position.y = move.toValue as! CGFloat
         view.layer?.opacity = alphaValue
-        
-        
     }
     
+    var staggerDelay: CFTimeInterval {
+        return 2
+    }
     
     func fadeViewOut(_ view:NSView){
         fadeViewTo(0, view: view)
@@ -203,46 +82,168 @@ class Util {
     }
     
     
-    func getStaggerDelay()->CFTimeInterval{ return 2}
-    
     func fadeViewsInStaggered(_ views:[NSView]){
         var delay:CFTimeInterval = 0
         for view in views {
             fadeViewTo(1, view: view, delay: delay)
-            delay += getStaggerDelay()
+            delay += staggerDelay
         }
     }
     
-    func fadeViewsOutStaggered(_ views:[NSView]){
-        var delay:CFTimeInterval = 0
-        for view in views {
-            fadeViewTo(0, view: view, delay: delay)
-            delay += getStaggerDelay()
-        }
-    }
-
-    static func formatBytes(_ byteCount:UInt64) -> String {
-        let formatter = ByteCountFormatter()
-        let formatted = formatter.string(fromByteCount: Int64(byteCount))
-        return formatted
+    func changeWindowHeight(_ window:NSWindow, view:NSView, newHeight:CGFloat=0) {
+        var frame = window.frame
+        frame.origin.y += frame.size.height; // origin.y is top Y coordinate now
+        frame.origin.y -= newHeight // new Y coordinate for the origin
+        frame.size.height = newHeight
+        frame.size = CGSize(width: frame.size.width, height: newHeight)
+        window.setFrame(frame, display: true, animate: true)
     }
     
-    static func getFileSizeForFilePath(_ filePath:String) -> UInt64 {
-        
-        do {
-            let atts:NSDictionary = try FileManager.default.attributesOfItem(atPath: filePath) as NSDictionary
-            return atts.fileSize()
-        } catch _ {
-        }
-        
-        return 1
-    }
-    
-    static func synced(_ lock: Any, closure: () -> ()) {
-        objc_sync_enter(lock)
-        closure()
-        objc_sync_exit(lock)
-    }
 }
 
+extension NSUserNotification {
+    
+    static func deliver(_ title:String, moreInfo:String, sound:Bool=true) -> Void {
+        let unc = NSUserNotificationCenter.default
+        let notification = NSUserNotification()
+        notification.title = title
+        notification.informativeText = moreInfo
+        if sound == true {
+            notification.soundName = NSUserNotificationDefaultSoundName
+        }
+        unc.deliver(notification)
+    }
 
+    
+}
+
+let filesystem = FileManager.default
+
+extension FileManager {
+    
+    func setUpSupportFolderScriptPath() throws {
+        let scriptFolder = supportFolderScriptPath()
+        
+        let scriptUrl = URL(fileURLWithPath: scriptFolder)
+        try createDirectory(at: scriptUrl, withIntermediateDirectories: true, attributes: nil)
+        let deleteToReset = scriptUrl.appendingPathComponent(deleteToResetName)
+        if let appVersion = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String {
+            if fileExists(atPath: deleteToReset.path) {
+                if checkVersionMatch(appVersion: appVersion, pathToVersionFile: deleteToReset) {
+                    // it a match, do nothing
+                    return
+                } else {
+                    try removeItem(at: deleteToReset)
+                }
+            }
+            try? copyInceptionScripts(userScriptFolder: scriptFolder)
+            try appVersion.write(to: deleteToReset, atomically: false, encoding: .utf8)
+        }
+    }
+
+    func supportFolderScriptPath() -> String {
+        let supportFolder:String = NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.applicationSupportDirectory, FileManager.SearchPathDomainMask.userDomainMask, true)[0]
+        let folder = "\(supportFolder)/AndroidTool"
+        let scriptFolder = "\(folder)/UserScripts"
+        return scriptFolder
+    }
+    
+    private func copyInceptionScripts(userScriptFolder: String) throws {
+        // copy files from UserScriptsInception to this new folder
+        if let resourceDir = Bundle.main.resourcePath {
+            let inceptionScriptDir = "\(resourceDir)/UserScriptsInception"
+            for fileName in try contentsOfDirectory(atPath: inceptionScriptDir) {
+                let destFile = "\(userScriptFolder)/\(fileName)"
+                if fileExists(atPath: destFile) {
+                    try removeItem(atPath: destFile)
+                }
+                try copyItem(
+                    atPath: "\(inceptionScriptDir)/\(fileName)",
+                    toPath: destFile)
+            }
+        }
+    }
+    
+    func revealScriptsFolder(){
+        let folder = supportFolderScriptPath()
+        NSWorkspace.shared.openFile(folder)
+    }
+
+    private func checkVersionMatch(appVersion: String, pathToVersionFile: URL) -> Bool {
+        if let savedVersion = try? String(contentsOf: pathToVersionFile, encoding: .utf8) {
+            return appVersion == savedVersion
+        } else {
+            return false
+        }
+    }
+    
+    func sizeOfFileAtPath(_ filePath:String) -> UInt64 {
+        if let atts:NSDictionary = try? attributesOfItem(atPath: filePath) as NSDictionary {
+            return atts.fileSize()
+        } else {
+            return 1
+        }
+    }
+    
+    func scriptsInScriptFolder(_ folder: String) -> [String] {
+        var files = [String]()
+        let someFiles = enumerator(atPath: folder)
+        while let file = someFiles?.nextObject() as? String  {
+            if file != ".DS_Store" && file != deleteToResetName {
+                files.append(file)
+            }
+        }
+        return files
+    }
+    
+    
+}
+
+extension String {
+    
+    func matches(_ regex:String) -> [String]? {
+        do {
+            let re = try NSRegularExpression(pattern: regex,
+                                             options: .caseInsensitive)
+            let matches = re.matches(in: self,
+                                     options: .reportProgress,
+                                     range:
+                NSRange(location: 0, length: utf16.count))
+            if matches.count != 0 {
+                var results = [String]()
+                for match in matches {
+                    let result = (self as NSString).substring(with: match.range(at: 1))
+                    results.append(result)
+                }
+                return results
+            } else {
+                return nil
+            }
+            
+        } catch {
+            print("Problem!")
+            return nil
+        }
+    }
+    
+    init(byteCount: UInt64) {
+        let formatter = ByteCountFormatter()
+        let formatted = formatter.string(fromByteCount: Int64(byteCount))
+        self = formatted
+    }
+
+
+    
+}
+
+struct Lock {
+    
+    private let token = NSObject()
+    
+    func synced(_ work: () -> ()) {
+        objc_sync_enter(token)
+        work()
+        objc_sync_exit(token)
+    }
+    
+}

--- a/AndroidTool/scriptsPopoverViewController.swift
+++ b/AndroidTool/scriptsPopoverViewController.swift
@@ -44,15 +44,13 @@ class scriptsPopoverViewController: NSViewController {
     // accepted answer here http://stackoverflow.com/questions/26180268/interface-builder-iboutlet-and-protocols-for-delegate-and-datasource-in-swift
     @IBOutlet var delegate : UserScriptDelegate!
     
-    let fileM = FileManager.default
-
     func setup(){
-        let folder = Util().getSupportFolderScriptPath()
-        let allScripts = Util().getScriptsInScriptFolder(folder)
+        let folder = filesystem.supportFolderScriptPath()
+        let allScripts = filesystem.scriptsInScriptFolder(folder)
 
-        if allScripts?.count > 0 {
-            addScriptsToView(allScripts!, view: self.view)
-            }
+        if allScripts.count > 0 {
+            addScriptsToView(allScripts, view: view)
+        }
     }
     
     func addScriptsToView(_ scripts:[String], view:NSView){
@@ -103,13 +101,13 @@ class scriptsPopoverViewController: NSViewController {
     
     @objc func runScriptClicked(_ sender:NSButton){
         let scriptName = "\(sender.title).sh"
-        let scriptPath = "\(Util().getSupportFolderScriptPath())/\(scriptName)"
+        let scriptPath = "\(filesystem.supportFolderScriptPath())/\(scriptName)"
         print("ready to run \(scriptPath)")
         runScript(scriptPath)
     }
     
     @objc func revealScriptFolderClicked(_ sender:NSButton) {
-        Util().revealScriptsFolder()
+        filesystem.revealScriptsFolder()
     }
     
     override func viewDidLoad() {


### PR DESCRIPTION
- refactors Utils into a set of extensions and a new base class or two
- removes some unnecessary `break`s, Swift has `break` by default, `fallthrough` is the special case 
- makes some optionals unnecessary through better designed initializer chains
- fixed one reference cycle by making a delegate `weak`

Not tested beyond making sure that it still can launch successfully.