### PR TITLE
Fix/bugre umi max record failure

### DIFF
--- a/AndroidTool/Scripts/startRecordingForSerial.sh
+++ b/AndroidTool/Scripts/startRecordingForSerial.sh
@@ -21,11 +21,11 @@ then
     # Get resolution if no custom res was specified
     if [[ ! $width ]]
     then
-        width=`"$adb" -s $serial shell dumpsys display | grep mDisplayWidth | awk -F '=' '{ print $2 }' | tr -d '\r\n'`
+        width=`"$adb" -s $serial shell dumpsys display | awk -F '=' '/mDisplayWidth/ { print $2 }' | tr -d '\r\n'`
     fi
     if [[ ! $height ]]
     then
-        height=`"$adb" -s $serial shell dumpsys display | grep mDisplayHeight | awk -F '=' '{ print $2 }' | tr -d '\r\n'`
+        height=`"$adb" -s $serial shell dumpsys display | awk -F '=' '/mDisplayHeight/ { print $2 }' | tr -d '\r\n'`
     fi
     sizeopt=""
     # Put a --size option only if both params are available
@@ -38,7 +38,7 @@ then
 else
     echo "Recording from phone..."
     
-    orientation=$("$adb" -s $serial shell dumpsys input | grep 'SurfaceOrientation' | awk '{ print $2 }')
+    orientation=$("$adb" -s $serial shell dumpsys input | awk '/SurfaceOrientation/ { print $2 }')
 
     sizeopt=""
     if [[ "${orientation//[$'\t\r\n ']}" != "0" ]]
@@ -50,7 +50,7 @@ else
     
     "$adb" -s $serial shell screenrecord --verbose --bit-rate $bitrate ${sizeopt} /sdcard/capture.mp4  # > $1/reclog.txt
     
-    ## [bugre] UMI Max with Android 7, is 1920x1080 device, but recording setting this resolution
+    ## [bugre] UMI Max with Android 7, is a 1920x1080 device, but recording setting this resolution
     ## results in error. Must be: 1920x1088 or let it record without resolution defined.
     ## Maybe this error also afects some other devices. 
     if [ "$ret" != "0" ]; then

--- a/AndroidTool/Scripts/startRecordingForSerial.sh
+++ b/AndroidTool/Scripts/startRecordingForSerial.sh
@@ -31,10 +31,10 @@ then
     # Put a --size option only if both params are available
     if [[ $width && $height ]]
     then
-        sizeopt=${width}x${height}
+        sizeopt="--size ${height}x${width}"
     fi
 
-    "$adb" -s $serial shell screenrecord --size $sizeopt --o raw-frames /sdcard/screencapture.raw
+    "$adb" -s $serial shell screenrecord $sizeopt --o raw-frames /sdcard/screencapture.raw
 else
     echo "Recording from phone..."
     


### PR DESCRIPTION
Hi Andrew

I've decided to invest some more time, and came up with a simple (maybe a little dirty) solution for my problem, where the UMI Max + Android 7, doesn't record because the 1920x1080   versus 1920x1088 resolution problem.

In the PR, i've added 3 quick commits:

1. fix for the issue #11 
2. after reviewing my fix, found a few lines above a call (when recording from a watch) that would fail the way the code was structured, as it would produce a call with "--size [empty] --raw.. "  instead of "..[empty] --raw...".
3. as the script already used awk for some var splitting, decided to replace all grep usage by awk native line pattern filtering `awk '/pattern/ {...}'`, and avoid the extra utility needed and extra call.

I've teste the resulting script with my UMI Max and a Samsung S7 and had no problems, but i haven't it tested on a watch, not could i compile the entire code, as i have not the environment available to do that.

If you think it's usable, fee free to merge the PR.

Regards,

